### PR TITLE
💄 适配思源 v3.1.4 代码块行号变更

### DIFF
--- a/style/module/code_block.css
+++ b/style/module/code_block.css
@@ -36,7 +36,6 @@
 
 .b3-typography .protyle-linenumber__rows,
 .protyle-wysiwyg .protyle-linenumber__rows {
-    padding: 34px 0 22px;
     opacity: 0.7;
     background-color: var(--b3-protyle-code-background);
 }


### PR DESCRIPTION
思源发布了新版本 v3.1.4，其中对代码片段的样式做了调整：
https://github.com/siyuan-note/siyuan/issues/10769

新版本发布后导致 tsundoku 主题的代码片段样式有问题，如下所示：
![image](https://github.com/user-attachments/assets/373a879e-8ddb-425e-b9a7-4a5d1d8568d7)

修复后的样式如下：
![image](https://github.com/user-attachments/assets/7dd37ad0-1d0b-4fc5-9bdb-51274af1b0f7)
